### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Modern solution for use icons on SolidJS
 
 ## ✨ Features
 
-- [16 Icon packs](https://github.com/x64Bits/solid-icons#included-icons-pack) totally ready to use.
+- [16 Icon packs](#-included-icons-pack) totally ready to use.
 - Compatible with [Solid Start](https://github.com/solidjs/solid-start) static generation and SSR.
 - Tree shakeable: What you take is what you get.
-- [Customizable](https://github.com/x64Bits/solid-icons#configuration) - receive props to extend their usefulness.
+- [Customizable](#%EF%B8%8F-configuration) - receive props to extend their usefulness.
 - [Reactivity](https://www.youtube.com/watch?v=J70HXl1KhWE), take advantage of SolidJS to react to changes in props.
-- [Just import and declare](https://github.com/x64Bits/solid-icons#usage) in your JSX to work out-the-box
+- [Just import and declare](#usage) in your JSX to work out-the-box
 - First class TypeScript support
 
 ## 📦 Installation


### PR DESCRIPTION
It couldn't correctly jump because it contained emojis. Also, it's better to omit the Github URL. Thank you :wink: