### PR TITLE
Hotfix remix filename

### DIFF
--- a/all_package.json
+++ b/all_package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-icons-all",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Bundle for Solid icons explorer",
   "author": "Ignacio Zsabo",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-icons",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Modern solution for use icons on SolidJS",
   "author": "Ignacio Zsabo",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "tslib": "^2.4.1",
     "typescript": "^4.9.4",
     "vite-plugin-solid": "^2.5.0",
-    "vitest": "^0.27.1"
+    "vitest": "^0.27.1",
+    "shx": "^0.3.4"
   },
   "engines": {
     "node": ">= 16"

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "tslib": "^2.4.1",
     "typescript": "^4.9.4",
     "vite-plugin-solid": "^2.5.0",
-    "vitest": "^0.27.1",
-    "shx": "^0.3.4"
+    "vitest": "^0.27.1"
   },
   "engines": {
     "node": ">= 16"

--- a/src/build/file-types.ts
+++ b/src/build/file-types.ts
@@ -12,7 +12,7 @@ function cjsTemplate(icon: IconContent): string {
 
 function moduleTemplate(icon: IconContent) {
   return /* javascript */ `
-  export function ${icon.fileName} (props) {
+  export function ${icon.fileName}(props) {
       return IconTemplate({
         a: ${JSON.stringify(icon.svgAttribs)},
         c: '${icon.contents}'

--- a/src/build/utils/file-name.ts
+++ b/src/build/utils/file-name.ts
@@ -39,12 +39,15 @@ export function formatFileName(filePath: string, packInfo: PackItem) {
     splittedPath[splittedPath.length - 1],
     packInfo.shortName
   );
-  const appendStyle = getStyle(packInfo.path, splittedPath);
+  const appendStyle = getStyle(packInfo.path, splittedPath).replace(
+    /[^a-zA-Z0-9]/g,
+    ""
+  );
   const rawFileName = removeExtension(name);
 
   const nameTemplate = `${capitalizeFirstLetter(
     packInfo.shortName
-  )}${appendStyle}${toPascalCase(rawFileName)}`;
+  )}${toPascalCase(appendStyle)}${toPascalCase(rawFileName)}`;
 
   return nameTemplate;
 }


### PR DESCRIPTION
In version 1.0.6 the icon packs were updated to their latest version and the Remix Icons has added two folders in an unexpected format, this version fix the problem introduced in the previous version.