### PR TITLE
fix: remix path color attr

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## CHANGELOG 1.0.8:
+
+- Fix remix color doesn't affect by `color` prop.
+
 ## CHANGELOG 1.0.5:
 
 - Fix csss color selector.

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ npm install solid-icons --save
 ## Usage
 
 ```jsx
-import { SiJavascript } from "solid-icons/si";
+import { TbBrandSolidjs } from "solid-icons/tb";
 
-<SiJavascript size={24} color="#2c4f7c" />;
+<TbBrandSolidjs size={24} color="#2c4f7c" />;
 ```
 
 ## Custom icon
@@ -107,9 +107,9 @@ const iconContent = {
 solid-icons components receive props like any SVG, you also have a few custom ones.
 
 ```jsx
-import { SiJavascript } from "solid-icons/si";
+import { TbBrandSolidjs } from "solid-icons/tb";
 
-<SiJavascript size={24} color="#2c4f7c" class="custom-icon" title="a11y" />;
+<TbBrandSolidjs size={24} color="#2c4f7c" class="custom-icon" title="a11y" />;
 ```
 
 | Key     | Default                  | Notes             |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-icons",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Modern solution for use icons on SolidJS",
   "author": "Ignacio Zsabo",
   "license": "MIT",
@@ -15,7 +15,8 @@
     "submodule": "node --no-warnings --loader ts-node/esm --experimental-specifier-resolution=node ./src/build/submodule.ts",
     "build": "node --no-warnings --loader ts-node/esm --experimental-specifier-resolution=node ./src/build/index.ts",
     "build:lib": "rollup --configPlugin @rollup/plugin-typescript -c",
-    "build:all": "shx rm -rf ./dist_all && shx mkdir ./dist_all && yarn build --web && shx cp ./all_package.json ./dist_all/package.json"
+    "build:all": "shx rm -rf ./dist_all && shx mkdir ./dist_all && yarn build --web && shx cp ./all_package.json ./dist_all/package.json",
+    "publish": "yarn build && npm publish ./dist"
   },
   "keywords": [
     "solidjs",

--- a/src/build/constants.ts
+++ b/src/build/constants.ts
@@ -47,6 +47,7 @@ export const NORMALIZE_PACK: Record<string, string> = {
   IO: "io",
   HI: "hi",
   TB: "tb",
+  RI: "ri",
 };
 
 export const NORMALIZE_FILE_NAME = {

--- a/src/build/optimize/index.ts
+++ b/src/build/optimize/index.ts
@@ -1,5 +1,6 @@
 import {
   normalizeOutline,
+  normalizeRi,
   normalizeTb,
   normalizeTwoTone,
 } from "./normalize-packs";
@@ -22,6 +23,9 @@ export async function optimizeContents(contents: string, shortName: string) {
       break;
     case NORMALIZE_PACK.AI:
       optimizedFile.data = normalizeTwoTone(optimizedFile.data);
+      break;
+    case NORMALIZE_PACK.RI:
+      optimizedFile.data = normalizeRi(optimizedFile.data);
       break;
   }
 

--- a/src/build/optimize/normalize-packs.ts
+++ b/src/build/optimize/normalize-packs.ts
@@ -18,6 +18,13 @@ export function normalizeTb(iconData: string): string {
   return iconData.replace(regex, replacement);
 }
 
+export function normalizeRi(iconData: string): string {
+  const regex = /<path/i;
+  const replacement = '<path fill="currentColor"';
+
+  return iconData.replace(regex, replacement);
+}
+
 export function normalizeOutline(iconData: string): string {
   let normalized = iconData;
 


### PR DESCRIPTION
This PR is to solve [this issue](https://github.com/x64Bits/solid-icons/issues/39), I added a function to modify the output in icons of the Remix package to add `fill="currentColor"` in each path, so that it can inherit the color from the svg, this is necessary since 1.0.5 when the issue of using color using css was fixed.