### PR TITLE
fix: tabler filled icons stroke-width being removed by svgo

### DIFF
--- a/src/build/optimize/index.ts
+++ b/src/build/optimize/index.ts
@@ -5,11 +5,27 @@ import {
   normalizeTwoTone,
 } from "./normalize-packs";
 import { svgoConfig } from "./svgo-config";
-import { optimize } from "svgo";
+import { Output, optimize } from "svgo";
 import { NORMALIZE_PACK } from "../constants";
 
 export async function optimizeContents(contents: string, shortName: string) {
-  const optimizedFile = optimize(contents, svgoConfig);
+  let optimizedFile: Output;
+  switch (shortName) {
+    case NORMALIZE_PACK.TB:
+      const tbSvgoConfig = {
+        ...svgoConfig,
+        plugins: svgoConfig.plugins?.filter((plugin) => {
+          if ((plugin as any).name == "removeAttributesBySelector") {
+            return false;
+          }
+        }),
+      };
+      optimizedFile = optimize(contents, tbSvgoConfig);
+      break;
+    default:
+      optimizedFile = optimize(contents, svgoConfig);
+      break;
+  }
 
   switch (shortName) {
     case NORMALIZE_PACK.IO:


### PR DESCRIPTION
It seems like the Tabler Icons did some update with the filled icons. You can see the messed up filled icons on the Solid Icons website.

All its icons have the stroke-width=2 on the <svg> tag, and the <path> all have their individual tags. svgo removes all the stroke attributes on non-svg tags, so the <path> get inherited the stroke-width=2 instead of its own stroke-width=0 which was deleted.

This fix clone a new svgo config for Tabler only so it doesn't affect other icon packs. It specificially removes the **removeAttributesBySelector** plugin.