### PR TITLE
feat: add output icon tests

### DIFF
--- a/all_package.json
+++ b/all_package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-icons-all",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Bundle for Solid icons explorer",
   "author": "Ignacio Zsabo",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-icons",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Modern solution for use icons on SolidJS",
   "author": "Ignacio Zsabo",
   "license": "MIT",

--- a/src/build/get-icons.ts
+++ b/src/build/get-icons.ts
@@ -13,7 +13,7 @@ const getIconContent = async (
   pack: PackItem
 ): Promise<IconContent> => {
   const rawFile = getFileByPath(path);
-  const optimizeFile = await optimizeContents(rawFile, pack.shortName);
+  const optimizeFile = await optimizeContents(rawFile, pack.shortName, path);
 
   const $ = load(optimizeFile.data, { xmlMode: true });
   const mountedElement = $("svg");
@@ -38,5 +38,5 @@ export function getIcons(pack: PackItem): Promise<IconContent[]> {
 
   return Promise.all(
     filesPath.map(async (path) => await getIconContent(path, pack))
-  );
+  ).then((contents) => contents.filter((icon) => !!icon.contents.length));
 }

--- a/src/build/optimize/index.ts
+++ b/src/build/optimize/index.ts
@@ -8,7 +8,11 @@ import { svgoConfig } from "./svgo-config";
 import { Output, optimize } from "svgo";
 import { NORMALIZE_PACK } from "../constants";
 
-export async function optimizeContents(contents: string, shortName: string) {
+export async function optimizeContents(
+  contents: string,
+  shortName: string,
+  path: string
+) {
   let optimizedFile: Output;
   switch (shortName) {
     case NORMALIZE_PACK.TB:
@@ -38,7 +42,7 @@ export async function optimizeContents(contents: string, shortName: string) {
       optimizedFile.data = normalizeOutline(optimizedFile.data);
       break;
     case NORMALIZE_PACK.AI:
-      optimizedFile.data = normalizeTwoTone(optimizedFile.data);
+      optimizedFile.data = normalizeTwoTone(optimizedFile.data, path);
       break;
     case NORMALIZE_PACK.RI:
       optimizedFile.data = normalizeRi(optimizedFile.data);

--- a/src/build/optimize/normalize-packs.ts
+++ b/src/build/optimize/normalize-packs.ts
@@ -1,21 +1,38 @@
-const aiReplacements = [
+const hiReplacements = [
   {
-    name: "stroke",
+    // Stroke `currentColor` by default
     regex: /stroke="none"/gi,
     replace: '<path stroke="currentColor"',
   },
   {
-    name: "fill",
+    // Stroke `currentColor` when fill are `none`
     regex: /fill="none"/gi,
     replace: 'fill="none" stroke="currentColor"',
   },
 ];
 
-export function normalizeTb(iconData: string): string {
-  const regex = /<path/i;
-  const replacement = '<path stroke="none"';
+const tbReplacements = [
+  {
+    // Remove stroke attr
+    regex: /<path/i,
+    replace: '<path stroke="none"',
+  },
+  {
+    // Replace default stroke color
+    regex: /stroke="#010202"/gi,
+    replace: 'stroke="none"',
+  },
+];
 
-  return iconData.replace(regex, replacement);
+export function normalizeTb(iconData: string): string {
+  let normalized = iconData;
+
+  for (let i = 0; i < tbReplacements.length; i++) {
+    const element = tbReplacements[i];
+    normalized = normalized.replace(element.regex, element.replace);
+  }
+
+  return normalized;
 }
 
 export function normalizeRi(iconData: string): string {
@@ -28,15 +45,19 @@ export function normalizeRi(iconData: string): string {
 export function normalizeOutline(iconData: string): string {
   let normalized = iconData;
 
-  for (let i = 0; i < aiReplacements.length; i++) {
-    const element = aiReplacements[i];
+  for (let i = 0; i < hiReplacements.length; i++) {
+    const element = hiReplacements[i];
     normalized = normalized.replace(element.regex, element.replace);
   }
 
   return normalized;
 }
 
-export function normalizeTwoTone(iconData: string): string {
+export function normalizeTwoTone(iconData: string, path: string): string {
+  if (!path.includes("twotone")) {
+    return iconData;
+  }
+
   const regex = /fill="currentColor"/i;
   const replacement = 'fill="currentColor" fill-opacity="0.6"';
 

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -30,7 +30,7 @@ export function IconTemplate(iconSrc: IconTree, props: IconProps): JSX.Element {
 
   return (
     <svg
-      stroke={iconSrc.a.stroke}
+      stroke={iconSrc.a?.stroke}
       color={props.color || "currentColor"}
       fill={props.color || "currentColor"}
       stroke-width="0"

--- a/test/output.jsx
+++ b/test/output.jsx
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { render, cleanup } from "solid-testing-library";
+
+import * as tbIcons from "../dist/tb/index.js";
+import * as riIcons from "../dist/ri/index.js";
+import * as aiIcons from "../dist/ai/index.js";
+import packages from "../src/build/packages.json";
+
+function countPaths(container) {
+  return container.querySelectorAll("path, rect").length;
+}
+
+describe("Icons in dist folder should be rendered correctly", () => {
+  afterEach(cleanup);
+
+  for (const packageInfo of packages) {
+    const { shortName, packName } = packageInfo;
+
+    describe(`Icons from ${packName} Icon Pack`, () => {
+      test(`Render icons from ${packName} icon pack`, async () => {
+        const iconPack = await import(`../dist/${shortName}/index.js`);
+
+        for (const iconKey in iconPack) {
+          const Icon = iconPack[iconKey];
+
+          const { container, unmount } = render(() => <Icon />);
+          const numPaths = countPaths(container);
+
+          if (numPaths === 0) {
+            throw new Error(`Failed icon: ${shortName}:${iconKey}`);
+          }
+
+          expect(numPaths).toBeGreaterThan(0);
+          unmount();
+        }
+      });
+    });
+  }
+});
+
+describe("Tabler output SVG", () => {
+  /**
+   * For generate Tabler icons, a different SVGO configuration is
+   * used to avoid problems with stroke, here
+   * is a PR that address this issue: https://github.com/x64Bits/solid-icons/pull/42
+   */
+  afterEach(cleanup);
+
+  for (const iconName in tbIcons) {
+    const Icon = tbIcons[iconName];
+
+    test(`Test normalization on Tabler Icon: ${iconName}`, () => {
+      const { container, unmount } = render(() => <Icon />);
+      const renderedSvg = container.querySelector("svg");
+
+      const pathElements = renderedSvg.querySelectorAll("path");
+      pathElements.forEach((pathElement) => {
+        // Assert that each <path> element has a "stroke" attribute with the value "none" or null
+        const strokeValue = pathElement.getAttribute("stroke");
+        expect(strokeValue === "none" || strokeValue === null).toBe(true);
+      });
+
+      unmount();
+    });
+  }
+});
+
+describe("Remix Icons output SVG", () => {
+  afterEach(cleanup);
+
+  for (const iconName in riIcons) {
+    const Icon = riIcons[iconName];
+
+    test(`Test normalization on Remix icons Icon: ${iconName}`, () => {
+      const { container, unmount } = render(() => <Icon />);
+      const renderedSvg = container.querySelector("svg");
+
+      const pathElements = renderedSvg.querySelectorAll("path");
+
+      // Iterate through each <path> element
+      pathElements.forEach((pathElement) => {
+        // Assert that the "fill" attribute is set to "currentColor"
+        expect(pathElement.getAttribute("fill")).toBe("currentColor");
+      });
+
+      unmount();
+    });
+  }
+});
+
+describe("Ant Design icons SVG", () => {
+  afterEach(cleanup);
+
+  for (const iconName in aiIcons) {
+    const Icon = aiIcons[iconName];
+
+    test(`Should display correct opacity on two tone icon: ${iconName}`, () => {
+      const { container, unmount } = render(() => <Icon />);
+      const renderedSvg = container.querySelector("svg");
+
+      // Get the <path> elements within the SVG
+      const pathElements = renderedSvg.querySelectorAll("path");
+
+      // Check if the icon name includes "twotone"
+      const isTwotone = iconName.toLocaleLowerCase().includes("twotone");
+
+      // Iterate through each <path> element
+      const fillOpacity06Count = Array.from(pathElements).filter(
+        (pathElement) => pathElement.getAttribute("fill-opacity") === "0.6"
+      ).length;
+
+      if (isTwotone) {
+        expect(fillOpacity06Count).toBe(1);
+      } else {
+        expect(fillOpacity06Count).toBe(0);
+      }
+
+      unmount();
+    });
+  }
+});


### PR DESCRIPTION
This PR integrates test cases aimed at validating the correct output and rendering of the icons on each package.

Details:
* Added a test to validate that all generated icons are valid and contain valid SVG elements.
* Tests were added that validate the output of the following icon packages:
    * Validate that Tabler icons do not contain a `stroke` that malformed the generated icons.
    * `path` elements generated in Remix icons must have `fill="currentColor"` to render correctly.
    * Elements that use two tones in Ant Design Icons should be the only ones that have `fill-opacity="0.6"`

Problems detected by these same tests were also corrected:
* A VSCode icon had no content.
* A Table icon defaults to a `stroke="#010202"`
* Some Ant Design icons were getting a `fill-opacity="0.6"` due to the way they were being validated if they were two tone icons.
* The SVG wrapper was failing to get the `stroke` from the attributes even though it was not present.

The next step with this would be to integrate the tests into Github actions and validate each PR with these tests.