### PR TITLE
fix: mergeProps import

### DIFF
--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -6,7 +6,8 @@ import {
   onCleanup,
   splitProps,
 } from "solid-js";
-import { isServer, mergeProps, ssr } from "solid-js/web";
+import { mergeProps } from "solid-js";
+import { isServer, ssr } from "solid-js/web";
 
 type SVGSVGElementTags = JSX.SVGElementTags["svg"];
 


### PR DESCRIPTION
Using `eslint-plugin-solid` dependency.

Fix
```console
9:20  warning  Prefer importing mergeProps from "solid-js"                                                           solid/imports
```